### PR TITLE
Fix Travis CI badge hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Hardware Platform
 
-[![Build Status](https://api.travis-ci.org/opencomputeproject/ohub.png?branch=master)](https://api.travis-ci.org/opencomputeproject/ohub)
+[![Build Status](https://api.travis-ci.org/opencomputeproject/ohub.png?branch=master)](https://travis-ci.org/opencomputeproject/ohub)
 
 This aim of this project is to create a collaborative platform for designing and sharing open hardware
 projects.


### PR DESCRIPTION
It should go to the Travis build page